### PR TITLE
Bug fixing in ed_evaluators.py

### DIFF
--- a/src/metrics/ed_evaluators.py
+++ b/src/metrics/ed_evaluators.py
@@ -843,7 +843,7 @@ class ModelDependentEvaluator(EDEvaluator):
 
         # the whole instance is the target anomaly (and larger than the sample length)
         if instance_length > self.min_instance_length:
-            if self.large_anomalies_coverage == ['center', 'end']:
+            if self.large_anomalies_coverage in ['center', 'end']:
                 if self.large_anomalies_coverage == 'center':
                     # lean more towards the instance start if different parities
                     sample_start = floor((instance_length - sample_length) / 2)


### PR DESCRIPTION
In line 846 of ed_evaluators.py file the 
if self.large_anomalies_coverage == ['center', 'end']:

results always to 'all' coverage policy. 

Corrected version should be : 

if self.large_anomalies_coverage in ['center', 'end']: